### PR TITLE
Update fido2-utils.sh

### DIFF
--- a/fido2-utils.sh
+++ b/fido2-utils.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 DISK="/dev/nvme0n1p3"
 
+array_getNth() { 
+   shift "$(( $1 + 1 ))"; 
+   printf '%s\n' "$1"; 
+}
+
+array_length() { 
+   echo "$#"; 
+}
+
 fido2_device() {
     device=$(fido2-token -L | sed 's/:.*//')
     if [ -z "$device" ] ; then
@@ -10,9 +19,13 @@ fido2_device() {
     fi
 }
 
+fido2_get_token_users() {
+    token_id=$(cryptsetup luksDump "$1" | grep -E '^\s+[0-9]+: systemd-fido2$' | sed -e 's/\s\+\([0-9]\+\):.*/\1/')
+    echo "$token_id"
+}
+
 fido2_get_token() {
-    token_id=$(cryptsetup luksDump "$1" | grep -E '^\s+[0-9]+: systemd-fido2$' | head -1 | sed -e 's/\s\+\([0-9]\+\):.*/\1/')
-    cryptsetup token export "$1" --token-id=$token_id
+    cryptsetup token export "$1" --token-id=$2
 }
 
 fido2_is_pin_required() {
@@ -20,8 +33,8 @@ fido2_is_pin_required() {
     test "$pin_required" = "true"
 }
 
-fido2_authenticate() {
-    token_json=$(fido2_get_token "$2")
+fido2_pin_check() {
+    token_json=$(fido2_get_token "$2" "$3")
     param_file=$(mktemp)
     use_pin=$(echo $token_json | jq -r '."fido2-clientPin-required"')
     if [ "$use_pin" = "true" ] ; then
@@ -43,7 +56,25 @@ fido2_authenticate() {
         assert_flags="$assert_flags -t uv=$(echo $token_json | jq -r '."fido2-uv-required"')"
     fi
 
-    assertion=$(echo -n "$pin" | setsid fido2-assert $assert_flags -i "$param_file" $(fido2_device) 2> /dev/null || (rm -f $param_file ; echo "Wrong PIN." 1>&2 ; exit 1))
+    assertion=$(echo -n "$pin" | setsid fido2-assert $assert_flags -i "$param_file" $(fido2_device) 2> /dev/null || (rm -f $param_file ; printf '%s' "Wrong"))
     rm -f $param_file
     printf '%s' "$assertion" | tail -1
+}
+
+fido2_authenticate() {
+   positionFidoUsers=$(fido2_get_token_users "$2")
+   totalUsers=$(($(array_length $positionFidoUsers)-1))
+   authOk=""
+   for i in $(seq 0 $totalUsers)
+   do
+      result=$(fido2_pin_check $1 $2 "$(array_getNth $i $positionFidoUsers)")
+      if [ $totalUsers -gt 0 ] && [ "$result" != "Wrong" ]; then
+          authOk=$result
+      fi
+   done
+   if [ -z $authOk ]; then
+       printf '%s'  "Wrong PIN."
+   else
+       printf '%s'  "$authOk"
+   fi
 }

--- a/fido2-utils.sh
+++ b/fido2-utils.sh
@@ -68,7 +68,7 @@ fido2_authenticate() {
    for i in $(seq 0 $totalUsers)
    do
       result=$(fido2_pin_check $1 $2 "$(array_getNth $i $positionFidoUsers)")
-      if [ $totalUsers -gt 0 ] && [ "$result" != "Wrong" ]; then
+      if [ $totalUsers -ge 0 ] && [ "$result" != "Wrong" ]; then
           authOk=$result
       fi
    done


### PR DESCRIPTION
The original version only allowed authentication of the first user registered in LUKs. Now the user limit is limited to the capacity of LUKs. Therefore, you can have more than one fido2 token registered in LUKs and authentication for any of them will occur successfully.